### PR TITLE
Implemented automatic documentation generation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,11 +9,38 @@ on:
       - 'serverless.yml'
       - 'template-kaskadi-lambda.js'
       - 'layer/**'
+      - 'docs/**'
 jobs:
-  deploy:
+  generate-docs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Import GPG key
+      uses: crazy-max/ghaction-import-gpg@v2
+      with:
+        git_user_signingkey: true
+        git_commit_gpgsign: true
+      env:
+        GPG_PRIVATE_KEY: ${{ secrets.KASKADI_BOT_GPG_PRIVATE_KEY }}
+        PASSPHRASE: ${{ secrets.KASKADI_BOT_GPG_PRIVATE_PASSPHRASE }}
+    - name: Generate documentation
+      uses: kaskadi/action-generate-docs@master
+      with:
+        type: lambda
+        template: docs/template.md
+  deploy:
+    runs-on: ubuntu-latest
+    needs: generate-docs
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 12
+        registry-url: https://registry.npmjs.org/
+    - name: Pull latest commit
+      run: |
+        git config pull.rebase false
+        git pull
     - name: Install dependencies
       run: npm i
     - name: serverless check

--- a/docs/template.md
+++ b/docs/template.md
@@ -1,0 +1,57 @@
+![](https://img.shields.io/github/package-json/v/kaskadi/template-kaskadi-lambda)
+![](https://img.shields.io/badge/code--style-standard-blue)
+![](https://img.shields.io/github/license/kaskadi/template-kaskadi-lambda?color=blue)
+
+**GitHub Actions workflows status**
+
+[![](https://img.shields.io/github/workflow/status/kaskadi/template-kaskadi-lambda/deploy?label=deployed&logo=Amazon%20AWS)](https://github.com/kaskadi/template-kaskadi-lambda/actions?query=workflow%3Adeploy)
+[![](https://img.shields.io/github/workflow/status/kaskadi/template-kaskadi-lambda/build?label=build&logo=mocha)](https://github.com/kaskadi/template-kaskadi-lambda/actions?query=workflow%3Abuild)
+[![](https://img.shields.io/github/workflow/status/kaskadi/template-kaskadi-lambda/syntax-check?label=syntax-check&logo=serverless)](https://github.com/kaskadi/template-kaskadi-lambda/actions?query=workflow%3Asyntax-check)
+
+**CodeClimate**
+
+[![](https://img.shields.io/codeclimate/maintainability/kaskadi/template-kaskadi-lambda?label=maintainability&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/template-kaskadi-lambda)
+[![](https://img.shields.io/codeclimate/tech-debt/kaskadi/template-kaskadi-lambda?label=technical%20debt&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/template-kaskadi-lambda)
+[![](https://img.shields.io/codeclimate/coverage/kaskadi/template-kaskadi-lambda?label=test%20coverage&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/template-kaskadi-lambda)
+
+**LGTM**
+
+[![](https://img.shields.io/lgtm/grade/javascript/github/kaskadi/template-kaskadi-lambda?label=code%20quality&logo=LGTM)](https://lgtm.com/projects/g/kaskadi/template-kaskadi-lambda/?mode=list&logo=LGTM)
+
+:point_right: **Badges here** :point_left:
+
+****
+
+# Testing
+
+`mocha`, `chai`, `nyc` & `standard` are available as dev dependencies.
+
+A `build` workflow (see [here](./.github/workflows/build.yml)) is running on `pull request` and will execute your test suite before allowing you to merge your PR. It also has a `coverage` job already prepared that you can comment out as soon as your testing is in place and your `REPORTER_ID` is in the repository secrets. This is the ID on _Code Climate_ used for uploading code coverage reports.
+
+Along `build`, a `syntax-check` workflow will also run to check your `serverless.yml` file syntax.
+
+****
+
+# Documentation
+
+This repository comes with a `generate-docs` job inside of the `deploy` workflow that generates documentation automatically for you by reading your main `serverless.yml` configuration file and extracting meta data of all lambda functions you defined. See [here](https://github.com/kaskadi/action-generate-docs) for more information.
+
+If you would like to see the workflow configuration, head [here](./.github/workflows/deploy.yml).
+
+You can configure the template used to generate the action documentation [here](./docs/template.md).
+
+****
+
+# Deploying
+
+Deploying to AWS is done automatically via a `deploy` workflow (see [here](./.github/workflows/deploy.yml)). This workflow will run on `push` to `master`. Before publishing, it checks for syntax error in your `serverless.yml` file.
+
+**You'll have to switch the command from `--version` to `deploy -v` in the [workflow configuration file](./.github/workflows/deploy.yml) to actually deploy!**
+
+**Warning: you may need to manually deploy the first time via `Serverless` CLI locally.**
+
+****
+
+<!-- do not touch: automatically generated documentation goes here -->
+{{>main}}
+<!-- do not touch: automatically generated documentation goes here -->


### PR DESCRIPTION
**Changes description**
Implemented automatic documentation generation using `action-generate-docs` GitHub action inside of `deploy` workflow` and `docs/template.md` as template.

**New features**
- _documentation template:_ added documentation template under `docs/template.md`

**Updated features**
- _`deploy` workflow:_ added `generate-docs` job inside of `deploy` workflow. This uses `action-generate-docs` action as well as `docs/template.md` as template