### PR TITLE
Implemented static code analysis

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,15 +3,38 @@ on:
   pull_request:
     branches:
       - 'master'
+      - 'release/**'
       - 'dev'
     types: [opened, reopened, edited, synchronize]
     paths:
       - 'template-kaskadi-lambda.js'
+      - 'layer/**'
       - 'test/**'
       - 'package.json'
 jobs:
+  # scan code using CodeQL
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - 'javascript'
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1
   build:
     runs-on: ubuntu-latest
+    needs: analyze
     steps:
     - uses: actions/checkout@v2
     - name: Install dependencies
@@ -21,6 +44,7 @@ jobs:
   # *** Can use this job instead when tests are properly in place and REPORTER_ID has been added to the repository secrets 
   # coverage:
     # runs-on: ubuntu-latest
+    # needs: analyze
     # steps:
     # - uses: actions/checkout@v2
     # - name: Install dependencies

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,8 +14,29 @@ env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_KEY_SECRET }}
 jobs:
+  # scan code using CodeQL
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language:
+          - 'javascript'
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1
   deploy:
     runs-on: ubuntu-latest
+    needs: analyze
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,22 @@ jobs:
       uses: github/codeql-action/autobuild@v1
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v1
-  deploy:
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    needs: analyze
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 12
+        registry-url: https://registry.npmjs.org/
+    - name: Install dependencies
+      run: npm i
+    - name: Test
+      run: npm test
+  syntax-check:
+    name: syntax-check
     runs-on: ubuntu-latest
     needs: analyze
     steps:
@@ -49,6 +64,17 @@ jobs:
       uses: serverless/github-action@master
       with:
         args: deploy --noDeploy
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [test, syntax-check]
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: 12
+        registry-url: https://registry.npmjs.org/
+    - name: Install dependencies
+      run: npm i
     - name: serverless deploy
       uses: serverless/github-action@master
       with:

--- a/.github/workflows/syntax-check.yml
+++ b/.github/workflows/syntax-check.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
       - 'master'
+      - 'release/**'
       - 'dev'
     types: [opened, reopened, edited, synchronize]
     paths:

--- a/docs/template.md
+++ b/docs/template.md
@@ -15,10 +15,6 @@
 [![](https://img.shields.io/codeclimate/tech-debt/kaskadi/template-kaskadi-lambda?label=technical%20debt&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/template-kaskadi-lambda)
 [![](https://img.shields.io/codeclimate/coverage/kaskadi/template-kaskadi-lambda?label=test%20coverage&logo=Code%20Climate)](https://codeclimate.com/github/kaskadi/template-kaskadi-lambda)
 
-**LGTM**
-
-[![](https://img.shields.io/lgtm/grade/javascript/github/kaskadi/template-kaskadi-lambda?label=code%20quality&logo=LGTM)](https://lgtm.com/projects/g/kaskadi/template-kaskadi-lambda/?mode=list&logo=LGTM)
-
 <!-- You can add badges inside of this section if you'd like -->
 
 ****
@@ -28,6 +24,8 @@
 `mocha`, `chai`, `nyc` & `standard` are available as dev dependencies.
 
 A `build` workflow (see [here](./.github/workflows/build.yml)) is running on `pull request` and will execute your test suite before allowing you to merge your PR. It also has a `coverage` job already prepared that you can comment out as soon as your testing is in place and your `REPORTER_ID` is in the repository secrets. This is the ID on _Code Climate_ used for uploading code coverage reports.
+
+Beside running your unit tests, this workflow also runs a static code analysis to find any vulnerability in your code. If a vulnerability is found, the workflow will directly fail and a notification will appear in the `Security` tab of your repository.
 
 Along `build`, a `syntax-check` workflow will also run to check your `serverless.yml` file syntax.
 
@@ -47,7 +45,10 @@ You can configure the template used to generate the action documentation [here](
 
 # Deploying
 
-Deploying to AWS is done automatically via a `deploy` workflow (see [here](./.github/workflows/deploy.yml)). This workflow will run on `push` to `master`. Before publishing, it checks for syntax error in your `serverless.yml` file.
+Deploying to AWS is done automatically via a `deploy` workflow (see [here](./.github/workflows/deploy.yml)). This workflow will run on `push`. Before publishing it:
+1. performs a static code analysis of the layer to detect any vulnerabilities. If a vulnerability is found, the workflow will directly fail. A notification will also appear in the `Security` tab of your repository.
+2. checks the syntax of `serverless.yml` for any errors
+3. run any tests you may have set up with `npm test`
 
 **You'll have to switch the command from `--version` to `deploy -v` in the [workflow configuration file](./.github/workflows/deploy.yml) to actually deploy!**
 

--- a/template-kaskadi-lambda.js
+++ b/template-kaskadi-lambda.js
@@ -9,3 +9,5 @@ module.exports.handler = async (event) => {
     })
   }
 }
+
+// force


### PR DESCRIPTION
**Changes description**
Added GitHub official static code analysis (via `CodeQL`, same as `LGTM`) inside of `build` and `deploy` workflows.

**Updated features**
- _`build`/`deploy` workflows:_ added static code analysis for vulnerability as a first step of the workflow. If this steps fails, the downstream steps will not run. Any vulnerabilities will be reported by the code analysis actions inside of the `Security` tab of the repository. Also fixed triggers.
- _`deploy` workflow:_ restructured workflow to first run static code analysis then unit tests and syntax check in parallel to then finish with deployment if all succeed.
- _documentation template:_ updated badges accordingly. Also added explanation regarding static code analysis.